### PR TITLE
wercker integration (Close #9)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "jassa",
-  "version": "0.5.0-SNAPSHOT",
+  "version": "0.6.0",
   "homepage": "https://github.com/GeoKnow/Jassa",
   "authors": [
     "Claus Stadler <cstadler@informatik.uni-leipzig.de>"

--- a/wercker.yml
+++ b/wercker.yml
@@ -8,9 +8,9 @@ build:
         name: Make sure gulp is installed
         code: sudo npm install gulp -g
     - npm-install
-#    - script:
-#        name: Run fulltest (incl. coveralls)
-#        code: gulp fulltest
+    - script:
+        name: Run fulltest (incl. coveralls)
+        code: gulp fulltest
     - script:
         name: Generate dist
         code: gulp browserify
@@ -30,6 +30,7 @@ deploy:
     - leipert/git-push:
          gh_token: $GH_TOKEN
          host: github.com
-         branch: bowerTest
+         repo: GeoKnow/Jassa-Bower
+         branch: master
          basedir: dist
          tag: bower


### PR DESCRIPTION
Fixes #9.

Someone with the sufficient rights has to create a wercker account and add this app for this to work.
Currently wercker runs `gulp fulltest` and `gulp docs`.
The generated docs will be pushed to the branch gh-pages.
Example of generated docs can be seen here: https://leipert.github.io/Jassa-Core/

If something else is needed let me know, for example email or IRC notification.

The wercker profile of my fork can be found here: https://app.wercker.com/#applications/53f14060836da8ab08000737
